### PR TITLE
test: refactor approve_and_fund

### DIFF
--- a/src/memecoin_rewards/tests.cairo
+++ b/src/memecoin_rewards/tests.cairo
@@ -4,8 +4,9 @@ use memecoin_staking::memecoin_rewards::interface::{
 };
 use memecoin_staking::memecoin_staking::interface::{IMemeCoinStakingDispatcher, StakeDuration};
 use memecoin_staking::test_utils::{
-    TestCfg, approve_and_stake, calculate_points, deploy_memecoin_rewards_contract,
-    deploy_memecoin_staking_contract, load_value, memecoin_staking_test_setup,
+    TestCfg, approve_and_fund, approve_and_stake, calculate_points,
+    deploy_memecoin_rewards_contract, deploy_memecoin_staking_contract, load_value,
+    memecoin_staking_test_setup,
 };
 use memecoin_staking::types::Amount;
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -116,10 +117,7 @@ fn test_claim_rewards() {
     staking_contract_balance += amount;
 
     let fund_amount = cfg.default_fund;
-    cheat_caller_address_once(contract_address: cfg.token_address, caller_address: cfg.funder);
-    token_dispatcher.approve(spender: cfg.rewards_contract, amount: fund_amount.into());
-    cheat_caller_address_once(contract_address: cfg.rewards_contract, caller_address: cfg.funder);
-    rewards_dispatcher.fund(amount: fund_amount);
+    approve_and_fund(:cfg, :fund_amount);
 
     let points = calculate_points(:amount, :stake_duration);
     let reward_cycle = 0;
@@ -140,10 +138,7 @@ fn test_claim_rewards() {
     approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
     staking_contract_balance += amount;
 
-    cheat_caller_address_once(contract_address: cfg.token_address, caller_address: cfg.funder);
-    token_dispatcher.approve(spender: cfg.rewards_contract, amount: fund_amount.into());
-    cheat_caller_address_once(contract_address: cfg.rewards_contract, caller_address: cfg.funder);
-    rewards_dispatcher.fund(amount: fund_amount);
+    approve_and_fund(:cfg, :fund_amount);
 
     let points = calculate_points(:amount, :stake_duration) / 2;
     let reward_cycle = 1;
@@ -166,7 +161,6 @@ fn test_claim_rewards() {
 fn test_claim_rewards_points_exceeds_cycle_points() {
     let cfg = memecoin_staking_test_setup();
     let staker_address = cfg.staker_address;
-    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
     let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
 
     let amount = cfg.default_stake;
@@ -174,10 +168,7 @@ fn test_claim_rewards_points_exceeds_cycle_points() {
     approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
 
     let fund_amount = cfg.default_fund;
-    cheat_caller_address_once(contract_address: cfg.token_address, caller_address: cfg.funder);
-    token_dispatcher.approve(spender: cfg.rewards_contract, amount: fund_amount.into());
-    cheat_caller_address_once(contract_address: cfg.rewards_contract, caller_address: cfg.funder);
-    rewards_dispatcher.fund(amount: fund_amount);
+    approve_and_fund(:cfg, :fund_amount);
 
     let points = calculate_points(:amount, :stake_duration) + 1;
     let reward_cycle = 0;

--- a/src/test_utils.cairo
+++ b/src/test_utils.cairo
@@ -1,3 +1,6 @@
+use memecoin_staking::memecoin_rewards::interface::{
+    IMemeCoinRewardsDispatcher, IMemeCoinRewardsDispatcherTrait,
+};
 use memecoin_staking::memecoin_staking::interface::{
     IMemeCoinStakingConfigDispatcher, IMemeCoinStakingConfigDispatcherTrait,
     IMemeCoinStakingDispatcher, IMemeCoinStakingDispatcherTrait, StakeDuration, StakeDurationTrait,
@@ -155,4 +158,14 @@ pub fn calculate_points(amount: Amount, stake_duration: StakeDuration) -> u128 {
     let points = amount * multiplier.into();
 
     points
+}
+
+pub fn approve_and_fund(cfg: TestCfg, fund_amount: Amount) {
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+    cheat_caller_address_once(contract_address: cfg.token_address, caller_address: cfg.funder);
+    token_dispatcher.approve(spender: cfg.rewards_contract, amount: fund_amount.into());
+
+    let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
+    cheat_caller_address_once(contract_address: cfg.rewards_contract, caller_address: cfg.funder);
+    rewards_dispatcher.fund(amount: fund_amount);
 }


### PR DESCRIPTION
# Add `approve_and_fund` utility function for tests

This PR introduces a new utility function `approve_and_fund` in the test utilities to simplify the process of funding the rewards contract in tests. The function handles both the token approval and the funding operation in a single call.

The PR also refactors the `test_claim_rewards` test to use this new utility function, replacing duplicate code blocks with the new helper function.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/39)
<!-- Reviewable:end -->