### PR TITLE
feat(staking): add claim_rewards function

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -14,6 +14,9 @@ pub(crate) enum Error {
     REWARDS_CONTRACT_NOT_SET,
     REWARDS_CONTRACT_ALREADY_SET,
     CLAIM_POINTS_EXCEEDS_CYCLE_POINTS,
+    STAKE_NOT_FOUND,
+    STAKE_NOT_VESTED,
+    STAKE_ALREADY_CLAIMED,
 }
 
 impl DescribableError of Describable<Error> {
@@ -31,6 +34,9 @@ impl DescribableError of Describable<Error> {
             Error::REWARDS_CONTRACT_NOT_SET => "Rewards contract not set",
             Error::REWARDS_CONTRACT_ALREADY_SET => "Rewards contract already set",
             Error::CLAIM_POINTS_EXCEEDS_CYCLE_POINTS => "Claim points exceeds cycle points",
+            Error::STAKE_NOT_FOUND => "Stake not found",
+            Error::STAKE_NOT_VESTED => "Stake not vested",
+            Error::STAKE_ALREADY_CLAIMED => "Stake already claimed",
         }
     }
 }

--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -97,7 +97,7 @@ pub(crate) impl StakeDurationImpl of StakeDurationTrait {
 }
 
 /// Stake info for each stake.
-#[derive(starknet::Store, Drop, Serde)]
+#[derive(starknet::Store, Drop, Serde, Copy)]
 pub struct StakeInfo {
     /// The reward cycle number.
     /// Stakes in the same reward cycle share a points / rewards ratio,
@@ -136,11 +136,13 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
         Time::now() >= self.get_vesting_time()
     }
 
-    fn get_claimed(self: @StakeInfo) -> bool {
+    fn is_claimed(self: @StakeInfo) -> bool {
         *self.claimed
     }
 
     fn set_claimed(ref self: StakeInfo) {
+        assert!(self.is_vested(), "{}", Error::STAKE_NOT_VESTED);
+        assert!(!self.is_claimed(), "{}", Error::STAKE_ALREADY_CLAIMED);
         self.claimed = true;
     }
 }

--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -32,6 +32,11 @@ pub trait IMemeCoinStaking<TContractState> {
 
     /// Get the `ContractAddress` of the rewards contract associated with the staking contract.
     fn get_rewards_contract(self: @TContractState) -> ContractAddress;
+
+    /// Claims the rewards for a specific stake.
+    fn claim_rewards(
+        ref self: TContractState, stake_duration: StakeDuration, stake_index: Index,
+    ) -> Amount;
 }
 
 pub mod Events {
@@ -102,6 +107,8 @@ pub struct StakeInfo {
     amount: Amount,
     /// The vesting time (the time when rewards can be claimed for this stake).
     vesting_time: Timestamp,
+    /// Indicates if the stake has been claimed.
+    claimed: bool,
 }
 
 #[generate_trait]
@@ -110,7 +117,7 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
         let time_delta = stake_duration.to_time_delta();
         assert!(time_delta.is_some(), "{}", Error::INVALID_STAKE_DURATION);
         let vesting_time = Time::now().add(delta: time_delta.unwrap());
-        StakeInfo { reward_cycle, amount, vesting_time }
+        StakeInfo { reward_cycle, amount, vesting_time, claimed: false }
     }
 
     fn get_reward_cycle(self: @StakeInfo) -> Cycle {
@@ -127,5 +134,13 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
 
     fn is_vested(self: @StakeInfo) -> bool {
         Time::now() >= self.get_vesting_time()
+    }
+
+    fn get_claimed(self: @StakeInfo) -> bool {
+        *self.claimed
+    }
+
+    fn set_claimed(ref self: StakeInfo) {
+        self.claimed = true;
     }
 }

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -15,6 +15,7 @@ pub mod MemeCoinStaking {
         Vec, VecTrait,
     };
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use starkware_utils::types::time::time::Time;
     use starkware_utils::utils::AddToStorage;
 
     #[storage]
@@ -136,6 +137,26 @@ pub mod MemeCoinStaking {
             total_points
         }
 
+        fn claim_rewards(
+            ref self: ContractState, stake_duration: StakeDuration, stake_index: Index,
+        ) -> Amount {
+            let staker_address = get_caller_address();
+            let rewards_contract = self.get_rewards_contract();
+            let (reward_cycle, points) = self
+                .claim_stake(:staker_address, :stake_duration, :stake_index);
+            let rewards_contract_dispatcher = IMemeCoinRewardsDispatcher {
+                contract_address: rewards_contract,
+            };
+            let token_dispatcher = self.token_dispatcher.read();
+            let caller_address = get_caller_address();
+
+            let rewards = rewards_contract_dispatcher.claim_rewards(:points, :reward_cycle);
+            token_dispatcher.transfer(recipient: caller_address, amount: rewards.into());
+
+            // TODO: Emit event.
+            rewards
+        }
+
         fn get_rewards_contract(self: @ContractState) -> ContractAddress {
             let rewards_contract = self.rewards_contract_dispatcher.read();
             assert!(rewards_contract.is_some(), "{}", Error::REWARDS_CONTRACT_NOT_SET);
@@ -201,6 +222,42 @@ pub mod MemeCoinStaking {
             // The vector is initialized in the constructor with one element,
             // so this value will never underflow.
             self.total_points_per_reward_cycle.len() - 1
+        }
+
+        fn calculate_points(
+            ref self: ContractState, stake_duration: StakeDuration, amount: Amount,
+        ) -> u128 {
+            let multiplier = stake_duration.get_multiplier();
+            assert!(multiplier.is_some(), "{}", Error::INVALID_STAKE_DURATION);
+            let points = amount * multiplier.unwrap().into();
+            points
+        }
+
+        fn claim_stake(
+            ref self: ContractState,
+            staker_address: ContractAddress,
+            stake_duration: StakeDuration,
+            stake_index: Index,
+        ) -> (Cycle, u128) {
+            let stake_info = self
+                .get_stake_info(staker_address: staker_address, :stake_duration, :stake_index);
+            assert!(stake_info.is_some(), "{}", Error::STAKE_NOT_FOUND);
+            let mut stake_info = stake_info.unwrap();
+            assert!(stake_info.get_vesting_time() <= Time::now(), "{}", Error::STAKE_NOT_VESTED);
+            assert!(!stake_info.get_claimed(), "{}", Error::STAKE_ALREADY_CLAIMED);
+            stake_info.set_claimed();
+            let amount = stake_info.get_amount();
+            let reward_cycle = stake_info.get_reward_cycle();
+            let points = self.calculate_points(:stake_duration, :amount);
+
+            self
+                .staker_info
+                .entry(key: staker_address)
+                .entry(key: stake_duration)
+                .at(index: stake_index)
+                .write(value: stake_info);
+
+            (reward_cycle, points)
         }
     }
 }

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -15,7 +15,6 @@ pub mod MemeCoinStaking {
         Vec, VecTrait,
     };
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
-    use starkware_utils::types::time::time::Time;
     use starkware_utils::utils::AddToStorage;
 
     #[storage]
@@ -141,32 +140,35 @@ pub mod MemeCoinStaking {
             ref self: ContractState, stake_duration: StakeDuration, stake_index: Index,
         ) -> Amount {
             let staker_address = get_caller_address();
-            let rewards_contract = self.get_rewards_contract();
-            let (reward_cycle, points) = self
-                .claim_stake(:staker_address, :stake_duration, :stake_index);
-            let rewards_contract_dispatcher = IMemeCoinRewardsDispatcher {
-                contract_address: rewards_contract,
-            };
-            let token_dispatcher = self.token_dispatcher.read();
-            let caller_address = get_caller_address();
+            let mut stake_info = self
+                .assert_stake_claimable(:staker_address, :stake_duration, :stake_index);
+            self
+                .mark_stake_as_claimed(
+                    :staker_address, :stake_duration, :stake_index, ref :stake_info,
+                );
+            let rewards = self.transfer_rewards_from_rewards_contract(:stake_info, :stake_duration);
 
-            let rewards = rewards_contract_dispatcher.claim_rewards(:points, :reward_cycle);
-            token_dispatcher.transfer(recipient: caller_address, amount: rewards.into());
+            let token_dispatcher = self.token_dispatcher.read();
+            token_dispatcher.transfer(recipient: staker_address, amount: rewards.into());
 
             // TODO: Emit event.
             rewards
         }
 
         fn get_rewards_contract(self: @ContractState) -> ContractAddress {
-            let rewards_contract = self.rewards_contract_dispatcher.read();
-            assert!(rewards_contract.is_some(), "{}", Error::REWARDS_CONTRACT_NOT_SET);
-
-            rewards_contract.unwrap().contract_address
+            self.get_rewards_contract_dispatcher().contract_address
         }
     }
 
     #[generate_trait]
     impl InternalMemeCoinStakingImpl of InternalMemeCoinStakingTrait {
+        fn get_rewards_contract_dispatcher(self: @ContractState) -> IMemeCoinRewardsDispatcher {
+            let rewards_contract_dispatcher = self.rewards_contract_dispatcher.read();
+            assert!(rewards_contract_dispatcher.is_some(), "{}", Error::REWARDS_CONTRACT_NOT_SET);
+
+            rewards_contract_dispatcher.unwrap()
+        }
+
         fn update_staker_info(
             ref self: ContractState,
             staker_address: ContractAddress,
@@ -233,22 +235,29 @@ pub mod MemeCoinStaking {
             points
         }
 
-        fn claim_stake(
+        fn assert_stake_claimable(
             ref self: ContractState,
             staker_address: ContractAddress,
             stake_duration: StakeDuration,
             stake_index: Index,
-        ) -> (Cycle, u128) {
-            let stake_info = self
-                .get_stake_info(staker_address: staker_address, :stake_duration, :stake_index);
+        ) -> StakeInfo {
+            let stake_info = self.get_stake_info(:staker_address, :stake_duration, :stake_index);
             assert!(stake_info.is_some(), "{}", Error::STAKE_NOT_FOUND);
             let mut stake_info = stake_info.unwrap();
-            assert!(stake_info.get_vesting_time() <= Time::now(), "{}", Error::STAKE_NOT_VESTED);
-            assert!(!stake_info.get_claimed(), "{}", Error::STAKE_ALREADY_CLAIMED);
+            assert!(stake_info.is_vested(), "{}", Error::STAKE_NOT_VESTED);
+            assert!(!stake_info.is_claimed(), "{}", Error::STAKE_ALREADY_CLAIMED);
+
+            stake_info
+        }
+
+        fn mark_stake_as_claimed(
+            ref self: ContractState,
+            staker_address: ContractAddress,
+            stake_duration: StakeDuration,
+            stake_index: Index,
+            ref stake_info: StakeInfo,
+        ) -> StakeInfo {
             stake_info.set_claimed();
-            let amount = stake_info.get_amount();
-            let reward_cycle = stake_info.get_reward_cycle();
-            let points = self.calculate_points(:stake_duration, :amount);
 
             self
                 .staker_info
@@ -257,7 +266,19 @@ pub mod MemeCoinStaking {
                 .at(index: stake_index)
                 .write(value: stake_info);
 
-            (reward_cycle, points)
+            stake_info
+        }
+
+        fn transfer_rewards_from_rewards_contract(
+            ref self: ContractState, stake_info: StakeInfo, stake_duration: StakeDuration,
+        ) -> Amount {
+            let amount = stake_info.get_amount();
+            let points = self.calculate_points(:stake_duration, :amount);
+            let reward_cycle = stake_info.get_reward_cycle();
+            let rewards_contract_dispatcher = self.get_rewards_contract_dispatcher();
+            let rewards = rewards_contract_dispatcher.claim_rewards(:points, :reward_cycle);
+
+            rewards
         }
     }
 }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -1,19 +1,23 @@
+use memecoin_staking::errors::Error;
 use memecoin_staking::memecoin_staking::event_test_utils::validate_new_stake_event;
 use memecoin_staking::memecoin_staking::interface::{
     IMemeCoinStakingConfigDispatcher, IMemeCoinStakingConfigDispatcherTrait,
-    IMemeCoinStakingDispatcher, IMemeCoinStakingDispatcherTrait, StakeDuration, StakeDurationTrait,
-    StakeInfoImpl,
+    IMemeCoinStakingDispatcher, IMemeCoinStakingDispatcherTrait, IMemeCoinStakingSafeDispatcher,
+    IMemeCoinStakingSafeDispatcherTrait, StakeDuration, StakeDurationTrait, StakeInfoImpl,
 };
 use memecoin_staking::test_utils::{
-    TestCfg, advance_time, approve_and_stake, calculate_points, cheat_staker_approve_staking,
-    deploy_memecoin_rewards_contract, deploy_memecoin_staking_contract, load_value,
+    TestCfg, advance_time, approve_and_fund, approve_and_stake, calculate_points,
+    cheat_staker_approve_staking, deploy_memecoin_rewards_contract,
+    deploy_memecoin_staking_contract, deploy_mock_erc20_contract, load_value,
     memecoin_staking_test_setup, verify_stake_info,
 };
 use memecoin_staking::types::{Amount, Cycle, Index};
-use openzeppelin::token::erc20::interface::IERC20Dispatcher;
+use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use snforge_std::{EventSpyTrait, EventsFilterTrait, spy_events};
+use starkware_utils::errors::Describable;
+use starkware_utils::types::time::time::TimeDelta;
 use starkware_utils_testing::event_test_utils::assert_number_of_events;
-use starkware_utils_testing::test_utils::cheat_caller_address_once;
+use starkware_utils_testing::test_utils::{assert_panic_with_error, cheat_caller_address_once};
 
 #[test]
 fn test_constructor() {
@@ -346,4 +350,126 @@ fn test_stake_is_vested() {
 
     advance_time(time_delta: stake_duration.to_time_delta().unwrap());
     assert!(stake_info.is_vested());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_claim_rewards_sanity() {
+    // Setup.
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let staking_safe_dispatcher = IMemeCoinStakingSafeDispatcher {
+        contract_address: cfg.staking_contract,
+    };
+
+    // Stake and fund.
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    let fund_amount = cfg.default_fund;
+    approve_and_fund(:cfg, :fund_amount);
+
+    // Claim rewards before vesting time.
+    let one_second = TimeDelta { seconds: 1 };
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap() - one_second);
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: cfg.staker_address,
+    );
+    let res = staking_safe_dispatcher.claim_rewards(:stake_duration, :stake_index);
+    assert_panic_with_error(res, Error::STAKE_NOT_VESTED.describe());
+
+    // Claim rewards after vesting time.
+    advance_time(time_delta: one_second);
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: cfg.staker_address,
+    );
+    let rewards = staking_dispatcher.claim_rewards(:stake_duration, :stake_index);
+    assert!(rewards == fund_amount);
+    let staker_balance = token_dispatcher.balance_of(account: staker_address);
+    assert!(staker_balance == fund_amount.into());
+
+    // Claim rewards again.
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: cfg.staker_address,
+    );
+    let res = staking_safe_dispatcher.claim_rewards(:stake_duration, :stake_index);
+    assert_panic_with_error(res, Error::STAKE_ALREADY_CLAIMED.describe());
+}
+
+#[test]
+#[should_panic(expected: "Stake not found")]
+fn test_claim_rewards_not_found() {
+    let cfg = memecoin_staking_test_setup();
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = 0;
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: cfg.staker_address,
+    );
+    staking_dispatcher.claim_rewards(:stake_duration, :stake_index);
+}
+
+#[test]
+#[should_panic(expected: "Rewards contract not set")]
+fn test_claim_rewards_rewards_contract_not_set() {
+    let mut cfg: TestCfg = Default::default();
+    cfg.token_address = deploy_mock_erc20_contract(funder: cfg.staker_address);
+    deploy_memecoin_staking_contract(ref :cfg);
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.claim_rewards(:stake_duration, :stake_index);
+}
+
+#[test]
+fn test_stake_info_claimed() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let mut stake_info = StakeInfoImpl::new(:reward_cycle, :amount, :stake_duration);
+    assert!(!stake_info.is_claimed());
+
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+    stake_info.set_claimed();
+    assert!(stake_info.is_claimed());
+}
+
+#[test]
+#[should_panic(expected: "Stake not vested")]
+fn test_stake_info_claimed_before_vesting() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let mut stake_info = StakeInfoImpl::new(:reward_cycle, :amount, :stake_duration);
+
+    stake_info.set_claimed();
+}
+
+#[test]
+#[should_panic(expected: "Stake already claimed")]
+fn test_stake_info_claimed_twice() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let mut stake_info = StakeInfoImpl::new(:reward_cycle, :amount, :stake_duration);
+
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+    stake_info.set_claimed();
+    stake_info.set_claimed();
 }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -142,7 +142,7 @@ fn test_get_stake_info_same_duration() {
         let stake_info = staking_dispatcher
             .get_stake_info(:staker_address, :stake_duration, :stake_index)
             .unwrap();
-        verify_stake_info(:stake_info, reward_cycle: 0, :amount, :stake_duration);
+        verify_stake_info(:stake_info, reward_cycle: 0, :amount, :stake_duration, claimed: false);
     }
 }
 
@@ -181,7 +181,7 @@ fn test_get_stake_info_different_durations() {
         let stake_info = staking_dispatcher
             .get_stake_info(:staker_address, :stake_duration, :stake_index)
             .unwrap();
-        verify_stake_info(:stake_info, reward_cycle: 0, :amount, :stake_duration);
+        verify_stake_info(:stake_info, reward_cycle: 0, :amount, :stake_duration, claimed: false);
     }
 }
 
@@ -322,7 +322,7 @@ fn test_close_reward_cycle() {
         let stake_info = staking_dispatcher
             .get_stake_info(:staker_address, :stake_duration, :stake_index)
             .unwrap();
-        verify_stake_info(:stake_info, :reward_cycle, :amount, :stake_duration);
+        verify_stake_info(:stake_info, :reward_cycle, :amount, :stake_duration, claimed: false);
     }
 }
 

--- a/src/test_utils.cairo
+++ b/src/test_utils.cairo
@@ -116,7 +116,11 @@ pub fn approve_and_stake(
 }
 
 pub fn verify_stake_info(
-    stake_info: StakeInfo, reward_cycle: Cycle, amount: Amount, stake_duration: StakeDuration,
+    stake_info: StakeInfo,
+    reward_cycle: Cycle,
+    amount: Amount,
+    stake_duration: StakeDuration,
+    claimed: bool,
 ) {
     let upper_vesting_time_bound = Time::now().add(delta: stake_duration.to_time_delta().unwrap());
     let lower_vesting_time_bound = upper_vesting_time_bound
@@ -125,6 +129,7 @@ pub fn verify_stake_info(
     assert!(stake_info.get_amount() == amount);
     assert!(stake_info.get_vesting_time() >= lower_vesting_time_bound);
     assert!(stake_info.get_vesting_time() <= upper_vesting_time_bound);
+    assert!(stake_info.get_claimed() == claimed);
 }
 
 pub fn memecoin_staking_test_setup() -> TestCfg {

--- a/src/test_utils.cairo
+++ b/src/test_utils.cairo
@@ -129,7 +129,7 @@ pub fn verify_stake_info(
     assert!(stake_info.get_amount() == amount);
     assert!(stake_info.get_vesting_time() >= lower_vesting_time_bound);
     assert!(stake_info.get_vesting_time() <= upper_vesting_time_bound);
-    assert!(stake_info.get_claimed() == claimed);
+    assert!(stake_info.is_claimed() == claimed);
 }
 
 pub fn memecoin_staking_test_setup() -> TestCfg {


### PR DESCRIPTION
# Add claim_rewards functionality

This PR adds the ability for users to claim rewards for their staked tokens after the vesting period has completed. The implementation includes:

- New error types for stake validation (not found, not vested, already claimed)
- Added `claimed` field to `StakeInfo` struct to track claim status
- Implemented `claim_rewards` method in the `IMemeCoinStaking` interface
- Added helper methods for stake claiming and points calculation
- Added comprehensive tests for the claim rewards functionality

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/40)
<!-- Reviewable:end -->