### PR TITLE
feat(staking): add StakeInfo method to show if stake is vested

### DIFF
--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -110,4 +110,8 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
     fn get_vesting_time(self: @StakeInfo) -> Timestamp {
         *self.vesting_time
     }
+
+    fn is_vested(self: @StakeInfo) -> bool {
+        Time::now() >= self.get_vesting_time()
+    }
 }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -1,9 +1,10 @@
 use memecoin_staking::memecoin_staking::interface::{
     IMemeCoinStakingConfigDispatcher, IMemeCoinStakingConfigDispatcherTrait,
-    IMemeCoinStakingDispatcher, IMemeCoinStakingDispatcherTrait, StakeDuration,
+    IMemeCoinStakingDispatcher, IMemeCoinStakingDispatcherTrait, StakeDuration, StakeDurationTrait,
+    StakeInfoImpl,
 };
 use memecoin_staking::test_utils::{
-    TestCfg, approve_and_stake, calculate_points, cheat_staker_approve_staking,
+    TestCfg, advance_time, approve_and_stake, calculate_points, cheat_staker_approve_staking,
     deploy_memecoin_rewards_contract, deploy_memecoin_staking_contract, load_value,
     memecoin_staking_test_setup, verify_stake_info,
 };
@@ -319,4 +320,17 @@ fn test_get_token_address() {
 
     let token_address = staking_dispatcher.get_token_address();
     assert!(token_address == cfg.token_address);
+}
+
+#[test]
+fn test_stake_is_vested() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_info = StakeInfoImpl::new(:reward_cycle, :amount, :stake_duration);
+    assert!(!stake_info.is_vested());
+
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+    assert!(stake_info.is_vested());
 }

--- a/src/test_utils.cairo
+++ b/src/test_utils.cairo
@@ -8,9 +8,11 @@ use memecoin_staking::memecoin_staking::interface::{
 };
 use memecoin_staking::types::{Amount, Cycle, Index};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare, load};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, load, start_cheat_block_timestamp_global,
+};
 use starknet::{ContractAddress, Store};
-use starkware_utils::types::time::time::Time;
+use starkware_utils::types::time::time::{Time, TimeDelta};
 use starkware_utils_testing::test_utils::cheat_caller_address_once;
 
 const INITIAL_SUPPLY: u256 = 100000;
@@ -170,4 +172,8 @@ pub fn approve_and_fund(cfg: TestCfg, fund_amount: Amount) {
     let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
     cheat_caller_address_once(contract_address: cfg.rewards_contract, caller_address: cfg.funder);
     rewards_dispatcher.fund(amount: fund_amount);
+}
+
+pub fn advance_time(time_delta: TimeDelta) {
+    start_cheat_block_timestamp_global(block_timestamp: Time::now().add(delta: time_delta).into());
 }


### PR DESCRIPTION
# Add `is_vested` method to StakeInfo

This PR adds a new `is_vested` method to the `StakeInfo` struct that checks if the current time is greater than or equal to the vesting time. The method is then used in the `claim_stake` function to simplify the vesting check logic.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/42)
<!-- Reviewable:end -->