### PR TITLE
feat(staking): add unstake function

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -18,6 +18,7 @@ pub(crate) enum Error {
     STAKE_NOT_VESTED,
     STAKE_ALREADY_CLAIMED,
     LOCK_POINTS_EXCEEDS_CYCLE_POINTS,
+    STAKE_ALREADY_UNSTAKED,
 }
 
 impl DescribableError of Describable<Error> {
@@ -39,6 +40,7 @@ impl DescribableError of Describable<Error> {
             Error::STAKE_NOT_VESTED => "Stake not vested",
             Error::STAKE_ALREADY_CLAIMED => "Stake already claimed",
             Error::LOCK_POINTS_EXCEEDS_CYCLE_POINTS => "Lock points exceeds cycle points",
+            Error::STAKE_ALREADY_UNSTAKED => "Stake already unstaked",
         }
     }
 }

--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -43,6 +43,13 @@ pub trait IMemeCoinStaking<TContractState> {
 
     /// Gets the current reward cycle number.
     fn get_current_reward_cycle(self: @TContractState) -> Cycle;
+
+    /// Unstakes a stake.
+    /// Can be called before vesting time, forfeiting the rewards.
+    /// Claims the rewards for the stake if it is vested and hasn't been claimed yet.
+    fn unstake(
+        ref self: TContractState, stake_duration: StakeDuration, stake_index: Index,
+    ) -> Amount;
 }
 
 pub mod Events {
@@ -130,6 +137,8 @@ pub struct StakeInfo {
     vesting_time: Timestamp,
     /// Indicates if the stake has been claimed.
     claimed: bool,
+    /// Indicates if the stake has been unstaked.
+    unstaked: bool,
 }
 
 #[generate_trait]
@@ -138,7 +147,7 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
         let time_delta = stake_duration.to_time_delta();
         assert!(time_delta.is_some(), "{}", Error::INVALID_STAKE_DURATION);
         let vesting_time = Time::now().add(delta: time_delta.unwrap());
-        StakeInfo { reward_cycle, amount, vesting_time, claimed: false }
+        StakeInfo { reward_cycle, amount, vesting_time, claimed: false, unstaked: false }
     }
 
     fn get_reward_cycle(self: @StakeInfo) -> Cycle {
@@ -165,5 +174,14 @@ pub(crate) impl StakeInfoImpl of StakeInfoTrait {
         assert!(self.is_vested(), "{}", Error::STAKE_NOT_VESTED);
         assert!(!self.is_claimed(), "{}", Error::STAKE_ALREADY_CLAIMED);
         self.claimed = true;
+    }
+
+    fn is_unstaked(self: @StakeInfo) -> bool {
+        *self.unstaked
+    }
+
+    fn set_unstaked(ref self: StakeInfo) {
+        assert!(!self.is_unstaked(), "{}", Error::STAKE_ALREADY_UNSTAKED);
+        self.unstaked = true;
     }
 }

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -15,7 +15,7 @@ pub mod MemeCoinStaking {
         Vec, VecTrait,
     };
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
-    use starkware_utils::utils::AddToStorage;
+    use starkware_utils::utils::{AddToStorage, SubFromStorage};
 
     #[storage]
     struct Storage {
@@ -162,6 +162,41 @@ pub mod MemeCoinStaking {
             rewards
         }
 
+        fn unstake(
+            ref self: ContractState, stake_duration: StakeDuration, stake_index: Index,
+        ) -> Amount {
+            let staker_address = get_caller_address();
+            let stake_info = self.get_stake_info(:staker_address, :stake_duration, :stake_index);
+            assert!(stake_info.is_some(), "{}", Error::STAKE_NOT_FOUND);
+            let mut stake_info = stake_info.unwrap();
+            assert!(!stake_info.is_unstaked(), "{}", Error::STAKE_ALREADY_UNSTAKED);
+
+            if stake_info.get_reward_cycle() == self.current_reward_cycle.read() {
+                // Hasn't been funded, no rewards to claim.
+                self.deduct_points_from_current_reward_cycle(:stake_duration, :stake_info);
+            } else if !stake_info.is_vested() {
+                // Has been funded, but not vested, can't claim rewards.
+                self.lock_rewards(:stake_info, :stake_duration);
+            } else if !stake_info.is_claimed() {
+                // Has been funded, and vested, can claim rewards.
+                self.claim_rewards(:stake_duration, :stake_index);
+                stake_info = self
+                    .get_stake_info(:staker_address, :stake_duration, :stake_index)
+                    .unwrap();
+            }
+            // If we entered none of the above, the stake is vested, but was already claimed.
+
+            let amount = self.transfer_stake_to_staker(:staker_address, :stake_info);
+
+            self
+                .mark_stake_as_unstaked(
+                    :staker_address, :stake_duration, :stake_index, ref :stake_info,
+                );
+            // TODO: Emit event.
+
+            amount
+        }
+
         fn get_rewards_contract(self: @ContractState) -> ContractAddress {
             self.get_rewards_contract_dispatcher().contract_address
         }
@@ -290,6 +325,56 @@ pub mod MemeCoinStaking {
         fn open_new_reward_cycle(ref self: ContractState) {
             self.current_reward_cycle.add_and_write(value: 1);
             self.current_cycle_points.write(value: 0);
+        }
+
+        fn deduct_points_from_current_reward_cycle(
+            ref self: ContractState, stake_duration: StakeDuration, stake_info: StakeInfo,
+        ) {
+            let amount = stake_info.get_amount();
+            let points = self.calculate_points(:stake_duration, :amount);
+            assert!(
+                points <= self.current_cycle_points.read(),
+                "{}",
+                Error::LOCK_POINTS_EXCEEDS_CYCLE_POINTS,
+            );
+
+            self.current_cycle_points.sub_and_write(value: points);
+        }
+
+        fn transfer_stake_to_staker(
+            ref self: ContractState, staker_address: ContractAddress, stake_info: StakeInfo,
+        ) -> Amount {
+            let token_dispatcher = self.token_dispatcher.read();
+            let amount = stake_info.get_amount();
+            token_dispatcher.transfer(recipient: staker_address, amount: amount.into());
+
+            amount
+        }
+
+        fn lock_rewards(
+            self: @ContractState, stake_info: StakeInfo, stake_duration: StakeDuration,
+        ) {
+            let amount = stake_info.get_amount();
+            let points = self.calculate_points(:stake_duration, :amount);
+            let reward_cycle = stake_info.get_reward_cycle();
+            let rewards_contract_dispatcher = self.get_rewards_contract_dispatcher();
+            rewards_contract_dispatcher.lock_rewards(:points, :reward_cycle);
+        }
+
+        fn mark_stake_as_unstaked(
+            ref self: ContractState,
+            staker_address: ContractAddress,
+            stake_duration: StakeDuration,
+            stake_index: Index,
+            ref stake_info: StakeInfo,
+        ) {
+            stake_info.set_unstaked();
+            self
+                .staker_info
+                .entry(key: staker_address)
+                .entry(key: stake_duration)
+                .at(index: stake_index)
+                .write(value: stake_info);
         }
     }
 }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -1,4 +1,7 @@
 use memecoin_staking::errors::Error;
+use memecoin_staking::memecoin_rewards::interface::{
+    IMemeCoinRewardsDispatcher, IMemeCoinRewardsDispatcherTrait,
+};
 use memecoin_staking::memecoin_staking::event_test_utils::{
     validate_claimed_rewards_event, validate_new_stake_event, validate_rewards_contract_set_event,
 };
@@ -15,7 +18,7 @@ use memecoin_staking::test_utils::{
 };
 use memecoin_staking::types::{Amount, Cycle, Index};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-use snforge_std::{EventSpyTrait, EventsFilterTrait, spy_events};
+use snforge_std::{CheatSpan, EventSpyTrait, EventsFilterTrait, cheat_caller_address, spy_events};
 use starkware_utils::errors::Describable;
 use starkware_utils::types::time::time::TimeDelta;
 use starkware_utils_testing::event_test_utils::assert_number_of_events;
@@ -578,4 +581,167 @@ fn test_reward_cycle_getters() {
     assert!(points == 0);
     let current_reward_cycle = staking_dispatcher.get_current_reward_cycle();
     assert!(current_reward_cycle == 1);
+}
+
+#[test]
+fn test_unstake_current_cycle_stake() {
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+    let staker_balance = token_dispatcher.balance_of(account: staker_address);
+    assert!(staker_balance == amount.into());
+    let staking_contract_balance = token_dispatcher.balance_of(account: cfg.staking_contract);
+    assert!(staking_contract_balance == 0);
+    let locked_rewards = rewards_dispatcher.get_locked_rewards();
+    assert!(locked_rewards == 0);
+}
+
+#[test]
+fn test_unstake_unvested_stake() {
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    let fund_amount = cfg.default_fund;
+    approve_and_fund(:cfg, :fund_amount);
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+    let staker_balance = token_dispatcher.balance_of(account: staker_address);
+    assert!(staker_balance == amount.into());
+    let staking_contract_balance = token_dispatcher.balance_of(account: cfg.staking_contract);
+    assert!(staking_contract_balance == 0);
+    let rewards_contract_balance = token_dispatcher.balance_of(account: cfg.rewards_contract);
+    assert!(rewards_contract_balance == fund_amount.into());
+    let locked_rewards = rewards_dispatcher.get_locked_rewards();
+    assert!(locked_rewards == fund_amount.into());
+}
+
+#[test]
+fn test_unstake_unclaimed_stake() {
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    let fund_amount = cfg.default_fund;
+    approve_and_fund(:cfg, :fund_amount);
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+    let staker_balance = token_dispatcher.balance_of(account: staker_address);
+    assert!(staker_balance == amount.into() + fund_amount.into());
+    let staking_contract_balance = token_dispatcher.balance_of(account: cfg.staking_contract);
+    assert!(staking_contract_balance == 0);
+    let rewards_contract_balance = token_dispatcher.balance_of(account: cfg.rewards_contract);
+    assert!(rewards_contract_balance == 0);
+    let locked_rewards = rewards_dispatcher.get_locked_rewards();
+    assert!(locked_rewards == 0);
+}
+
+#[test]
+fn test_unstake_claimed_stake() {
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let rewards_dispatcher = IMemeCoinRewardsDispatcher { contract_address: cfg.rewards_contract };
+    let token_dispatcher = IERC20Dispatcher { contract_address: cfg.token_address };
+
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    let fund_amount = cfg.default_fund;
+    approve_and_fund(:cfg, :fund_amount);
+    advance_time(time_delta: stake_duration.to_time_delta().unwrap());
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.claim_rewards(:stake_duration, :stake_index);
+
+    cheat_caller_address_once(
+        contract_address: cfg.staking_contract, caller_address: staker_address,
+    );
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+    let staker_balance = token_dispatcher.balance_of(account: staker_address);
+    assert!(staker_balance == amount.into() + fund_amount.into());
+    let staking_contract_balance = token_dispatcher.balance_of(account: cfg.staking_contract);
+    assert!(staking_contract_balance == 0);
+    let rewards_contract_balance = token_dispatcher.balance_of(account: cfg.rewards_contract);
+    assert!(rewards_contract_balance == 0);
+    let locked_rewards = rewards_dispatcher.get_locked_rewards();
+    assert!(locked_rewards == 0);
+}
+
+#[test]
+#[should_panic(expected: "Stake already unstaked")]
+fn test_unstake_twice() {
+    let cfg = memecoin_staking_test_setup();
+    let staker_address = cfg.staker_address;
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+
+    let amount: Amount = cfg.staker_supply;
+    let stake_duration = cfg.default_stake_duration;
+    let stake_index = approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+
+    cheat_caller_address(
+        contract_address: cfg.staking_contract,
+        caller_address: staker_address,
+        span: CheatSpan::TargetCalls(2),
+    );
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+    staking_dispatcher.unstake(:stake_duration, :stake_index);
+}
+
+#[test]
+fn test_stake_info_unstaked() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let mut stake_info = StakeInfoImpl::new(reward_cycle, amount, stake_duration);
+    assert!(!stake_info.is_unstaked());
+
+    stake_info.set_unstaked();
+    assert!(stake_info.is_unstaked());
+}
+
+#[test]
+#[should_panic(expected: "Stake already unstaked")]
+fn test_stake_info_unstaked_twice() {
+    let cfg: TestCfg = Default::default();
+    let reward_cycle = 0;
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    let mut stake_info = StakeInfoImpl::new(reward_cycle, amount, stake_duration);
+
+    stake_info.set_unstaked();
+    stake_info.set_unstaked();
 }


### PR DESCRIPTION
# Add unstake functionality

This PR adds the ability to unstake tokens before the vesting period is complete, allowing users to withdraw their staked tokens at any time. When unstaking:

- If the stake is in the current cycle (not yet funded), points are deducted from the current cycle
- If the stake is funded but not vested, points are deducted from the closed reward cycle
- If the stake is vested and not claimed, rewards are claimed automatically
- In all cases, the original staked amount is returned to the user

The implementation includes:
- New `unstake` method in the `IMemeCoinStaking` interface
- New `STAKE_ALREADY_UNSTAKED` error
- Added `unstaked` flag to `StakeInfo` struct
- Comprehensive test coverage for all unstaking scenarios

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/46)
<!-- Reviewable:end -->