### PR TITLE
fix(staking): add check to make sure the rewards contract is only set once

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -10,6 +10,7 @@ pub(crate) enum Error {
     REWARDS_TOKEN_MISMATCH,
     STAKING_TOKEN_MISMATCH,
     REWARDS_CONTRACT_NOT_SET,
+    REWARDS_CONTRACT_ALREADY_SET,
 }
 
 impl DescribableError of Describable<Error> {
@@ -23,6 +24,7 @@ impl DescribableError of Describable<Error> {
             Error::REWARDS_TOKEN_MISMATCH => "Rewards token mismatch",
             Error::STAKING_TOKEN_MISMATCH => "Staking token mismatch",
             Error::REWARDS_CONTRACT_NOT_SET => "Rewards contract not set",
+            Error::REWARDS_CONTRACT_ALREADY_SET => "Rewards contract already set",
         }
     }
 }

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -50,6 +50,8 @@ pub mod MemeCoinStaking {
     impl MemeCoinStakingConfigImpl of IMemeCoinStakingConfig<ContractState> {
         fn set_rewards_contract(ref self: ContractState, rewards_contract: ContractAddress) {
             assert!(get_caller_address() == self.owner.read(), "{}", Error::CALLER_IS_NOT_OWNER);
+            let current_rewards_contract = self.rewards_contract.read();
+            assert!(current_rewards_contract.is_none(), "{}", Error::REWARDS_CONTRACT_ALREADY_SET);
 
             // TODO: Consider removing this check.
             // This is redundant, and can't be tested

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -45,6 +45,21 @@ fn test_set_get_rewards_contract() {
 }
 
 #[test]
+#[should_panic(expected: "Rewards contract already set")]
+fn test_set_rewards_contract_already_set() {
+    let mut cfg: TestCfg = Default::default();
+    deploy_memecoin_staking_contract(ref :cfg);
+    let rewards_contract = deploy_memecoin_rewards_contract(ref :cfg);
+    let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
+
+    cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
+    dispatcher.set_rewards_contract(:rewards_contract);
+
+    cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
+    dispatcher.set_rewards_contract(:rewards_contract);
+}
+
+#[test]
 #[should_panic(expected: "Can only be called by the owner")]
 fn test_set_rewards_contract_wrong_caller() {
     let mut cfg: TestCfg = Default::default();


### PR DESCRIPTION
# Prevent setting rewards contract multiple times

This PR adds a check to prevent the rewards contract from being set more than once. It:

- Adds a new `REWARDS_CONTRACT_ALREADY_SET` error to the errors enum
- Adds a corresponding error message
- Modifies `set_rewards_contract` to check if a rewards contract is already set
- Adds a test case to verify the new behavior

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/48)
<!-- Reviewable:end -->