### PR TITLE
fix: staking contract now makes sure the rewards contract uses the same token

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -7,6 +7,7 @@ pub(crate) enum Error {
     CALLER_IS_NOT_REWARDS_CONTRACT,
     CLOSE_EMPTY_CYCLE,
     INVALID_STAKE_DURATION,
+    REWARDS_TOKEN_MISMATCH,
 }
 
 impl DescribableError of Describable<Error> {
@@ -17,6 +18,7 @@ impl DescribableError of Describable<Error> {
             Error::CALLER_IS_NOT_REWARDS_CONTRACT => "Can only be called by the rewards contract",
             Error::CLOSE_EMPTY_CYCLE => "Can't close reward cycle with no stakes",
             Error::INVALID_STAKE_DURATION => "Invalid stake duration",
+            Error::REWARDS_TOKEN_MISMATCH => "Rewards token mismatch",
         }
     }
 }

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -8,6 +8,7 @@ pub(crate) enum Error {
     CLOSE_EMPTY_CYCLE,
     INVALID_STAKE_DURATION,
     REWARDS_TOKEN_MISMATCH,
+    STAKING_TOKEN_MISMATCH,
 }
 
 impl DescribableError of Describable<Error> {
@@ -19,6 +20,7 @@ impl DescribableError of Describable<Error> {
             Error::CLOSE_EMPTY_CYCLE => "Can't close reward cycle with no stakes",
             Error::INVALID_STAKE_DURATION => "Invalid stake duration",
             Error::REWARDS_TOKEN_MISMATCH => "Rewards token mismatch",
+            Error::STAKING_TOKEN_MISMATCH => "Staking token mismatch",
         }
     }
 }

--- a/src/memecoin_rewards/interface.cairo
+++ b/src/memecoin_rewards/interface.cairo
@@ -1,4 +1,5 @@
 use memecoin_staking::types::Amount;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IMemeCoinRewards<TContractState> {
@@ -8,4 +9,7 @@ pub trait IMemeCoinRewards<TContractState> {
     /// Can only be called by the funder of the contract.
     /// Will fail if there are no stakes for the current reward cycle.
     fn fund(ref self: TContractState, amount: Amount);
+
+    /// Get the `ContractAddress` of the token used for rewards.
+    fn get_token_address(self: @TContractState) -> ContractAddress;
 }

--- a/src/memecoin_rewards/memecoin_rewards.cairo
+++ b/src/memecoin_rewards/memecoin_rewards.cairo
@@ -42,6 +42,10 @@ pub mod MemeCoinRewards {
         staking_address: ContractAddress,
         token_address: ContractAddress,
     ) {
+        let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: staking_address };
+        let staking_token_address = staking_dispatcher.get_token_address();
+        assert!(token_address == staking_token_address, "{}", Error::STAKING_TOKEN_MISMATCH);
+
         self.funder.write(value: funder);
         self
             .staking_dispatcher

--- a/src/memecoin_rewards/memecoin_rewards.cairo
+++ b/src/memecoin_rewards/memecoin_rewards.cairo
@@ -66,5 +66,9 @@ pub mod MemeCoinRewards {
                 );
             // TODO: Emit event.
         }
+
+        fn get_token_address(self: @ContractState) -> ContractAddress {
+            self.token_dispatcher.read().contract_address
+        }
     }
 }

--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -16,6 +16,9 @@ pub trait IMemeCoinStaking<TContractState> {
     /// Returns the `stake_index`.
     fn stake(ref self: TContractState, amount: Amount, stake_duration: StakeDuration) -> Index;
 
+    /// Get the `ContractAddress` of the token used for staking.
+    fn get_token_address(self: @TContractState) -> ContractAddress;
+
     /// Get info for a specific stake for `staker_address`.
     fn get_stake_info(
         self: @TContractState,

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -47,6 +47,10 @@ pub mod MemeCoinStaking {
         fn set_rewards_contract(ref self: ContractState, rewards_contract: ContractAddress) {
             assert!(get_caller_address() == self.owner.read(), "{}", Error::CALLER_IS_NOT_OWNER);
 
+            // TODO: Consider removing this check.
+            // This is redundant, and can't be tested
+            // since the rewards constructor will fail if the token doesn't match,
+            // but is still good to have.
             let rewards_contract_dispatcher = IMemeCoinRewardsDispatcher {
                 contract_address: rewards_contract,
             };
@@ -71,6 +75,10 @@ pub mod MemeCoinStaking {
             self.transfer_to_contract(sender: staker_address, :amount);
             // TODO: Emit event.
             index
+        }
+
+        fn get_token_address(self: @ContractState) -> ContractAddress {
+            self.token_dispatcher.read().contract_address
         }
 
         fn get_stake_info(

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -55,19 +55,6 @@ fn test_set_rewards_contract_wrong_caller() {
 }
 
 #[test]
-#[should_panic(expected: "Rewards token mismatch")]
-fn test_set_rewards_contract_token_mismatch() {
-    let mut cfg: TestCfg = Default::default();
-    deploy_memecoin_staking_contract(ref :cfg);
-    cfg.token_address = 'ANOTHER_TOKEN'.try_into().unwrap();
-    let rewards_contract = deploy_memecoin_rewards_contract(ref :cfg);
-    let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
-
-    cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
-    dispatcher.set_rewards_contract(:rewards_contract);
-}
-
-#[test]
 fn test_stake() {
     let cfg = memecoin_staking_test_setup();
     let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
@@ -303,4 +290,13 @@ fn test_close_reward_cycle() {
             .unwrap();
         verify_stake_info(:stake_info, :reward_cycle, :amount, :stake_duration);
     }
+}
+
+#[test]
+fn test_get_token_address() {
+    let cfg = memecoin_staking_test_setup();
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+
+    let token_address = staking_dispatcher.get_token_address();
+    assert!(token_address == cfg.token_address);
 }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -4,7 +4,8 @@ use memecoin_staking::memecoin_staking::interface::{
 };
 use memecoin_staking::test_utils::{
     TestCfg, approve_and_stake, calculate_points, cheat_staker_approve_staking,
-    deploy_memecoin_staking_contract, load_value, memecoin_staking_test_setup, verify_stake_info,
+    deploy_memecoin_rewards_contract, deploy_memecoin_staking_contract, load_value,
+    memecoin_staking_test_setup, verify_stake_info,
 };
 use memecoin_staking::types::{Amount, Cycle, Index};
 use openzeppelin::token::erc20::interface::IERC20Dispatcher;
@@ -30,7 +31,7 @@ fn test_constructor() {
 fn test_set_rewards_contract() {
     let mut cfg: TestCfg = Default::default();
     deploy_memecoin_staking_contract(ref :cfg);
-    let rewards_contract = cfg.rewards_contract;
+    let rewards_contract = deploy_memecoin_rewards_contract(ref :cfg);
     let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
 
     cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
@@ -50,6 +51,19 @@ fn test_set_rewards_contract_wrong_caller() {
     let rewards_contract = cfg.rewards_contract;
     let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
 
+    dispatcher.set_rewards_contract(:rewards_contract);
+}
+
+#[test]
+#[should_panic(expected: "Rewards token mismatch")]
+fn test_set_rewards_contract_token_mismatch() {
+    let mut cfg: TestCfg = Default::default();
+    deploy_memecoin_staking_contract(ref :cfg);
+    cfg.token_address = 'ANOTHER_TOKEN'.try_into().unwrap();
+    let rewards_contract = deploy_memecoin_rewards_contract(ref :cfg);
+    let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
+
+    cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
     dispatcher.set_rewards_contract(:rewards_contract);
 }
 


### PR DESCRIPTION
token

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/49)
<!-- Reviewable:end -->
