### PR TITLE
test: use less consts, more cfg

### DIFF
--- a/src/test_utils.cairo
+++ b/src/test_utils.cairo
@@ -10,10 +10,7 @@ use starknet::{ContractAddress, Store};
 use starkware_utils::types::time::time::Time;
 use starkware_utils_testing::test_utils::cheat_caller_address_once;
 
-pub const INITIAL_SUPPLY: u256 = 100000;
-pub const STAKER_SUPPLY: Amount = (INITIAL_SUPPLY / 2).try_into().unwrap();
-pub const DEFAULT_STAKE: Amount = 1000;
-pub const DEFAULT_FUND: Amount = 1000;
+const INITIAL_SUPPLY: u256 = 100000;
 
 #[derive(Drop, Copy)]
 pub struct TestCfg {
@@ -38,9 +35,9 @@ impl TestInitConfigDefault of Default<TestCfg> {
             staking_contract: 'STAKING_CONTRACT'.try_into().unwrap(),
             token_address: 'TOKEN_ADDRESS'.try_into().unwrap(),
             staker_address: 'STAKER_ADDRESS'.try_into().unwrap(),
-            staker_supply: STAKER_SUPPLY,
-            default_stake: DEFAULT_STAKE,
-            default_fund: DEFAULT_FUND,
+            staker_supply: (INITIAL_SUPPLY / 2).try_into().unwrap(),
+            default_stake: 1000,
+            default_fund: 1000,
             dummy_address: 'DUMMY_ADDRESS'.try_into().unwrap(),
         }
     }


### PR DESCRIPTION
# Refactor constants in test_utils.cairo

This PR refactors how constants are defined in the test utilities:
- Moves `INITIAL_SUPPLY` to be a private module constant
- Removes the global constants `STAKER_SUPPLY`, `DEFAULT_STAKE`, and `DEFAULT_FUND`
- Calculates these values directly in the `Default` implementation for `TestCfg`

This approach reduces redundancy while maintaining the same functionality.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/52)
<!-- Reviewable:end -->