### PR TITLE
feat(staking): add get_current_cycle_points function

### DIFF
--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -37,6 +37,9 @@ pub trait IMemeCoinStaking<TContractState> {
     fn claim_rewards(
         ref self: TContractState, stake_duration: StakeDuration, stake_index: Index,
     ) -> Amount;
+
+    /// Get the amount of points in the current open reward cycle.
+    fn get_current_cycle_points(self: @TContractState) -> u128;
 }
 
 pub mod Events {

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -163,6 +163,10 @@ pub mod MemeCoinStaking {
             rewards
         }
 
+        fn get_current_cycle_points(self: @ContractState) -> u128 {
+            self.total_points_in_current_reward_cycle.read()
+        }
+
         fn get_rewards_contract(self: @ContractState) -> ContractAddress {
             self.get_rewards_contract_dispatcher().contract_address
         }

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -523,3 +523,26 @@ fn test_stake_info_claimed_twice() {
     stake_info.set_claimed();
     stake_info.set_claimed();
 }
+
+#[test]
+fn test_get_current_cycle_points() {
+    let cfg = memecoin_staking_test_setup();
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
+    let staker_address = cfg.staker_address;
+
+    let points = staking_dispatcher.get_current_cycle_points();
+    assert!(points == 0);
+
+    // Stake and verify points.
+    let amount = cfg.default_stake_amount;
+    let stake_duration = cfg.default_stake_duration;
+    approve_and_stake(:cfg, :staker_address, :amount, :stake_duration);
+    let points = staking_dispatcher.get_current_cycle_points();
+    assert!(points == calculate_points(:amount, :stake_duration));
+
+    // Fund and verify points.
+    let fund_amount = cfg.default_fund;
+    approve_and_fund(:cfg, :fund_amount);
+    let points = staking_dispatcher.get_current_cycle_points();
+    assert!(points == 0);
+}


### PR DESCRIPTION
# Add `get_current_cycle_points` function to MemeCoinStaking contract

This PR adds a new function `get_current_cycle_points()` to the MemeCoinStaking contract that returns the amount of points in the current open reward cycle. The implementation simply reads the `total_points_in_current_reward_cycle` storage variable.

A test has been added to verify the function works correctly in different scenarios:
- When no staking has occurred (points = 0)
- After staking (points = calculated points based on amount and duration)
- After funding (points reset to 0 as a new cycle begins)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/53)
<!-- Reviewable:end -->