### PR TITLE
refactor(staking): use Option for rewards contract

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -9,6 +9,7 @@ pub(crate) enum Error {
     INVALID_STAKE_DURATION,
     REWARDS_TOKEN_MISMATCH,
     STAKING_TOKEN_MISMATCH,
+    REWARDS_CONTRACT_NOT_SET,
 }
 
 impl DescribableError of Describable<Error> {
@@ -21,6 +22,7 @@ impl DescribableError of Describable<Error> {
             Error::INVALID_STAKE_DURATION => "Invalid stake duration",
             Error::REWARDS_TOKEN_MISMATCH => "Rewards token mismatch",
             Error::STAKING_TOKEN_MISMATCH => "Staking token mismatch",
+            Error::REWARDS_CONTRACT_NOT_SET => "Rewards contract not set",
         }
     }
 }

--- a/src/memecoin_staking/interface.cairo
+++ b/src/memecoin_staking/interface.cairo
@@ -29,6 +29,9 @@ pub trait IMemeCoinStaking<TContractState> {
 
     /// Bumps current reward cycle, returns total points for the previous cycle.
     fn close_reward_cycle(ref self: TContractState) -> u128;
+
+    /// Get the `ContractAddress` of the rewards contract associated with the staking contract.
+    fn get_rewards_contract(self: @TContractState) -> ContractAddress;
 }
 
 /// Different stake durations.

--- a/src/memecoin_staking/memecoin_staking.cairo
+++ b/src/memecoin_staking/memecoin_staking.cairo
@@ -24,7 +24,7 @@ pub mod MemeCoinStaking {
         /// and funding the rewards contract.
         owner: ContractAddress,
         /// The address of the rewards contract associated with the staking contract.
-        rewards_contract: ContractAddress,
+        rewards_contract: Option<ContractAddress>,
         /// Stores the stake info per stake for each staker.
         staker_info: Map<ContractAddress, Map<StakeDuration, Vec<StakeInfo>>>,
         /// Stores the total points for each `reward_cycle`.
@@ -40,6 +40,10 @@ pub mod MemeCoinStaking {
         self.owner.write(value: owner);
         self.token_dispatcher.write(value: IERC20Dispatcher { contract_address: token_address });
         self.total_points_per_reward_cycle.push(value: 0);
+        // This contract's functionality is dependent on the rewards contract,
+        // it needs to be set after the rewards contract is deployed.
+        // This is set to None to indicate that the rewards contract is not set.
+        self.rewards_contract.write(value: None);
     }
 
     #[abi(embed_v0)]
@@ -61,7 +65,7 @@ pub mod MemeCoinStaking {
                 Error::REWARDS_TOKEN_MISMATCH,
             );
 
-            self.rewards_contract.write(value: rewards_contract);
+            self.rewards_contract.write(value: Some(rewards_contract));
             // TODO: Emit event.
         }
     }
@@ -99,11 +103,13 @@ pub mod MemeCoinStaking {
         }
 
         fn close_reward_cycle(ref self: ContractState) -> u128 {
+            let rewards_contract = self.get_rewards_contract();
             assert!(
-                get_caller_address() == self.rewards_contract.read(),
+                get_caller_address() == rewards_contract,
                 "{}",
                 Error::CALLER_IS_NOT_REWARDS_CONTRACT,
             );
+
             let curr_reward_cycle = self.get_current_reward_cycle();
             let total_points = self
                 .total_points_per_reward_cycle
@@ -114,6 +120,13 @@ pub mod MemeCoinStaking {
             // TODO: Emit event.
 
             total_points
+        }
+
+        fn get_rewards_contract(self: @ContractState) -> ContractAddress {
+            let rewards_contract = self.rewards_contract.read();
+            assert!(rewards_contract.is_some(), "{}", Error::REWARDS_CONTRACT_NOT_SET);
+
+            rewards_contract.unwrap()
         }
     }
 

--- a/src/memecoin_staking/tests.cairo
+++ b/src/memecoin_staking/tests.cairo
@@ -28,18 +28,19 @@ fn test_constructor() {
 }
 
 #[test]
-fn test_set_rewards_contract() {
+fn test_set_get_rewards_contract() {
     let mut cfg: TestCfg = Default::default();
     deploy_memecoin_staking_contract(ref :cfg);
     let rewards_contract = deploy_memecoin_rewards_contract(ref :cfg);
-    let dispatcher = IMemeCoinStakingConfigDispatcher { contract_address: cfg.staking_contract };
+    let config_dispatcher = IMemeCoinStakingConfigDispatcher {
+        contract_address: cfg.staking_contract,
+    };
+    let staking_dispatcher = IMemeCoinStakingDispatcher { contract_address: cfg.staking_contract };
 
     cheat_caller_address_once(contract_address: cfg.staking_contract, caller_address: cfg.owner);
-    dispatcher.set_rewards_contract(:rewards_contract);
+    config_dispatcher.set_rewards_contract(:rewards_contract);
 
-    let loaded_rewards_contract = load_value(
-        contract_address: cfg.staking_contract, storage_address: selector!("rewards_contract"),
-    );
+    let loaded_rewards_contract = staking_dispatcher.get_rewards_contract();
     assert!(loaded_rewards_contract == rewards_contract);
 }
 


### PR DESCRIPTION
# Make rewards_contract field optional in MemeCoinStaking contract

This PR changes the `rewards_contract` field in the `MemeCoinStaking` contract from a `ContractAddress` to an `Option<ContractAddress>`. This modification allows the staking contract to be deployed before the rewards contract, with the rewards contract address being set later.

Key changes:
- Initialize `rewards_contract` as `None` in the constructor
- Update `set_rewards_contract` to store the address as `Some(rewards_contract)`
- Add a helper method `get_rewards_contract()` that unwraps the option
- Update tests to handle the new option type with a new `load_option_value` utility function

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/54)
<!-- Reviewable:end -->