### PR TITLE
docs(rewards): clarify locking rewards is done by the staking contract

### DIFF
--- a/src/memecoin_rewards/interface.cairo
+++ b/src/memecoin_rewards/interface.cairo
@@ -23,6 +23,7 @@ pub trait IMemeCoinRewards<TContractState> {
     /// Lock the equivalent amount of rewards for a reward cycle
     /// given an amount of points.
     /// Used when a staker unstakes early.
+    /// Can only be called by the staking contract.
     fn lock_rewards(ref self: TContractState, points: u128, reward_cycle: Cycle);
 
     /// Get the amount of rewards locked.


### PR DESCRIPTION
### TL;DR

Added clarifying comment to the `lock_rewards` function in the `IMemeCoinRewards` trait.

### What changed?

Added a comment to the `lock_rewards` function in the `IMemeCoinRewards` trait specifying that this function can only be called by the staking contract. This improves the documentation by making the access control requirements explicit.

### How to test?

No testing is required as this is a documentation change only.

### Why make this change?

This change enhances the interface documentation by clearly indicating the access restrictions for the `lock_rewards` function. Making these restrictions explicit in the interface helps prevent misuse and improves developer understanding of the contract's security model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keep-starknet-strange/memecoin-staking/84)
<!-- Reviewable:end -->
